### PR TITLE
Add navbar_links params to admin settings

### DIFF
--- a/app/views/layouts/decidim/admin/settings.html.erb
+++ b/app/views/layouts/decidim/admin/settings.html.erb
@@ -13,6 +13,9 @@
       <li <% if is_active_link?(decidim_admin.edit_organization_homepage_path, /^\/admin\/organization\/homepage/) %> class="is-active" <% end %>>
         <%= link_to t("menu.homepage", scope: "decidim.admin"), decidim_admin.edit_organization_homepage_path %>
       </li>
+      <li <% if is_active_link?(decidim_admin.navbar_links_path) %> class="is-active" <% end %>>
+        <%= link_to t("menu.navbar_links", scope: "decidim.admin"), decidim_admin.navbar_links_path %>
+      </li>
       <li <% if is_active_link?(decidim_admin.scopes_path) %> class="is-active" <% end %>>
         <%= link_to t("menu.scopes", scope: "decidim.admin"), decidim_admin.scopes_path %>
       </li>


### PR DESCRIPTION
The admin settings view in decidim-polis do not contain the navbar_links link which prevents its use when deploying Pol.is