### PR TITLE
add missing svg assets

### DIFF
--- a/lib/decidim/polis/engine.rb
+++ b/lib/decidim/polis/engine.rb
@@ -15,7 +15,7 @@ module Decidim
       end
 
       initializer "decidim_polis.assets" do |app|
-        app.config.assets.precompile += %w(decidim_polis_manifest.js decidim_polis_manifest.css)
+        app.config.assets.precompile += %w(decidim_polis_manifest.js decidim_polis_manifest.css *.svg)
       end
     end
   end


### PR DESCRIPTION
#### What ? Why ? 

SVG assets are missing in assets pipeline.

#### Related to : 

- #24 

